### PR TITLE
fix(moderation): Adjust code to use limma legacy moderation code

### DIFF
--- a/R/groupComparisonTMT.R
+++ b/R/groupComparisonTMT.R
@@ -256,7 +256,7 @@ MSstatsModerateTTest = function(summarized, fitted_models, moderated) {
     eb_input_df = fitted_models[variance_df != 0 & !is.na(variance_df),
                                 variance_df]
     if (moderated) {
-        eb_fit = limma::squeezeVar(eb_input_s2, eb_input_df)
+        eb_fit = limma::squeezeVar(eb_input_s2, eb_input_df, legacy = TRUE)
         df_prior = eb_fit$df.prior
         variance_prior = eb_fit$var.prior
     } else { ## ordinary t statistic


### PR DESCRIPTION
## Motivation and Context

MSstatsTMT has a dependency on [limma::squeezeVar](https://github.com/Vitek-Lab/MSstatsTMT/blob/devel/R/groupComparisonTMT.R#L258-L265) and limma made this [update](https://code.bioconductor.org/browse/limma/commit/e8ff47777e7c25d6dcb9582d9fcb8f9c4fed9da1) to this function.  I upgraded limma to the latest version and reproduced the same error.  

In the context of assuming equal variance across proteins via variance moderation, limma adjusted how that variance is calculated if there are differing degrees of freedom across proteins (e.g. from differing amounts of missing values per protein).  This means MSstatsTMT could have different moderated analysis results based on versioning.

## Changes

- As a quick fix, we can use the legacy code and unit tests pass. 
- In the short term, I'll stick with legacy = TRUE to maintain the current functionality and pass the unit test so that MSstatsTMT passes the check on bioconductor.  
- Long term (pending): I'll make a future PR updating the tests and using the new version of squeezeVar.


## Tests
- Check succeeded locally with latest version of limma.
